### PR TITLE
feat: harden prediction deadline enforcement with qualifyingDeadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,18 @@ jobs:
   build-and-test:
     name: Build & Unit Tests
     runs-on: ubuntu-latest
+    container: gradle:8.7-jdk21
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
         with:
-          java-version: "21"
-          distribution: temurin
-          cache: gradle
+          path: |
+            /root/.gradle/caches
+            /root/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/libs.versions.toml') }}
+          restore-keys: gradle-
 
       - name: Run all unit tests
         run: ./gradlew test --no-daemon -q
@@ -33,6 +36,22 @@ jobs:
     needs: build-and-test
     steps:
       - uses: actions/checkout@v4
+
+      - name: Pre-pull infrastructure images (with retry)
+        run: |
+          pull_with_retry() {
+            local image=$1
+            for i in 1 2 3; do
+              docker pull "$image" && return 0
+              echo "  Pull failed for $image (attempt $i/3), retrying in 15s..."
+              sleep 15
+            done
+            echo "  Could not pull $image after 3 attempts"
+            return 1
+          }
+          pull_with_retry postgres:16-alpine  || exit 1
+          pull_with_retry redis:7-alpine      || exit 1
+          pull_with_retry rabbitmq:3-management-alpine || exit 1
 
       - name: Build and start all services
         run: docker compose up -d --build
@@ -60,13 +79,13 @@ jobs:
             return 1
           }
 
-          wait_healthy auth-service       8081 || exit 1
-          wait_healthy prediction-service 8082 || exit 1
-          wait_healthy league-service     8083 || exit 1
-          wait_healthy scoring-service    8084 || exit 1
-          wait_healthy f1-data-service        8085 || exit 1
-          wait_healthy notification-service  8086 || exit 1
-          wait_healthy api-gateway           8080 || exit 1
+          wait_healthy auth-service         8081 || exit 1
+          wait_healthy prediction-service   8082 || exit 1
+          wait_healthy league-service       8083 || exit 1
+          wait_healthy scoring-service      8084 || exit 1
+          wait_healthy f1-data-service      8085 || exit 1
+          wait_healthy notification-service 8086 || exit 1
+          wait_healthy api-gateway          8080 || exit 1
 
       - name: Smoke test - all routes reachable via api-gateway
         run: |
@@ -85,12 +104,12 @@ jobs:
             return 0
           }
 
-          check_route "/auth"        "http://localhost:8080/auth/api/v1/login"  || exit 1
-          check_route "/predictions" "http://localhost:8080/predictions/"        || exit 1
-          check_route "/leagues"     "http://localhost:8080/leagues/"            || exit 1
-          check_route "/scores"      "http://localhost:8080/scores/"             || exit 1
-          check_route "/f1"           "http://localhost:8080/f1/races"              || exit 1
-          check_route "/notifications" "http://localhost:8080/notifications/health" || exit 1
+          check_route "/auth"          "http://localhost:8080/auth/api/v1/login"     || exit 1
+          check_route "/predictions"   "http://localhost:8080/predictions/"          || exit 1
+          check_route "/leagues"       "http://localhost:8080/leagues/"              || exit 1
+          check_route "/scores"        "http://localhost:8080/scores/"               || exit 1
+          check_route "/f1"            "http://localhost:8080/f1/races"              || exit 1
+          check_route "/notifications" "http://localhost:8080/notifications/health"  || exit 1
 
       - name: Print all service logs on failure
         if: failure()
@@ -103,14 +122,16 @@ jobs:
   mobile-typecheck:
     name: Mobile TypeScript Check
     runs-on: ubuntu-latest
+    container: node:20
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: mobile/package-lock.json
+          path: mobile/node_modules
+          key: npm-${{ hashFiles('mobile/package-lock.json') }}
+          restore-keys: npm-
 
       - name: Install dependencies
         working-directory: mobile

--- a/build.gradle
+++ b/build.gradle
@@ -14,4 +14,7 @@ subprojects {
     java { toolchain { languageVersion = JavaLanguageVersion.of(21) } }
     repositories { mavenCentral() }
     test { useJUnitPlatform() }
+    dependencies {
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    }
 }

--- a/services/f1-data-service/src/main/java/com/f1predict/f1data/controller/RaceController.java
+++ b/services/f1-data-service/src/main/java/com/f1predict/f1data/controller/RaceController.java
@@ -1,0 +1,30 @@
+package com.f1predict.f1data.controller;
+
+import com.f1predict.f1data.repository.RaceRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+
+@RestController
+@RequestMapping("/races")
+public class RaceController {
+
+    private final RaceRepository raceRepository;
+
+    public RaceController(RaceRepository raceRepository) {
+        this.raceRepository = raceRepository;
+    }
+
+    record DeadlineResponse(String raceId, Instant qualifyingDeadline) {}
+
+    @GetMapping("/{raceId}/deadline")
+    public ResponseEntity<DeadlineResponse> getDeadline(@PathVariable String raceId) {
+        return raceRepository.findById(raceId)
+            .map(race -> ResponseEntity.ok(new DeadlineResponse(raceId, race.getQualifyingDeadline())))
+            .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/services/f1-data-service/src/main/java/com/f1predict/f1data/model/Race.java
+++ b/services/f1-data-service/src/main/java/com/f1predict/f1data/model/Race.java
@@ -27,6 +27,8 @@ public class Race {
 
     private Instant raceDate;
 
+    private Instant qualifyingDeadline;
+
     @Column(name = "is_sprint_weekend", nullable = false)
     private boolean sprintWeekend = false;
 
@@ -84,6 +86,14 @@ public class Race {
 
     public void setRaceDate(Instant raceDate) {
         this.raceDate = raceDate;
+    }
+
+    public Instant getQualifyingDeadline() {
+        return qualifyingDeadline;
+    }
+
+    public void setQualifyingDeadline(Instant qualifyingDeadline) {
+        this.qualifyingDeadline = qualifyingDeadline;
     }
 
     public boolean isSprintWeekend() {

--- a/services/f1-data-service/src/main/resources/db/migration/V2__add_qualifying_deadline.sql
+++ b/services/f1-data-service/src/main/resources/db/migration/V2__add_qualifying_deadline.sql
@@ -1,0 +1,2 @@
+ALTER TABLE races
+    ADD COLUMN qualifying_deadline TIMESTAMPTZ;

--- a/services/prediction-service/src/main/java/com/f1predict/prediction/client/F1DataClient.java
+++ b/services/prediction-service/src/main/java/com/f1predict/prediction/client/F1DataClient.java
@@ -1,0 +1,48 @@
+package com.f1predict.prediction.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.time.Instant;
+
+@Component
+public class F1DataClient {
+
+    private static final Logger log = LoggerFactory.getLogger(F1DataClient.class);
+
+    private final RestClient restClient;
+
+    public F1DataClient(@Value("${services.f1data-url}") String f1dataUrl) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(2000);
+        factory.setReadTimeout(3000);
+        this.restClient = RestClient.builder()
+            .baseUrl(f1dataUrl)
+            .requestFactory(factory)
+            .build();
+    }
+
+    record DeadlineResponse(String raceId, Instant qualifyingDeadline) {}
+
+    /**
+     * Returns the qualifying deadline for the race, or null if the race is unknown
+     * or the F1 data service is unavailable (fail open — caller should allow the operation).
+     */
+    public Instant getQualifyingDeadline(String raceId) {
+        try {
+            DeadlineResponse response = restClient.get()
+                .uri("/races/{raceId}/deadline", raceId)
+                .retrieve()
+                .body(DeadlineResponse.class);
+            return response != null ? response.qualifyingDeadline() : null;
+        } catch (RestClientException e) {
+            log.warn("F1 data service unavailable for deadline check — allowing submission. raceId={}", raceId);
+            return null;
+        }
+    }
+}

--- a/services/prediction-service/src/main/java/com/f1predict/prediction/controller/PredictionController.java
+++ b/services/prediction-service/src/main/java/com/f1predict/prediction/controller/PredictionController.java
@@ -2,6 +2,7 @@ package com.f1predict.prediction.controller;
 
 import com.f1predict.prediction.dto.BonusBetRequest;
 import com.f1predict.prediction.dto.BonusBetResponse;
+import com.f1predict.prediction.dto.InternalPredictionResponse;
 import com.f1predict.prediction.dto.PredictionResponse;
 import com.f1predict.prediction.dto.SubmitPredictionRequest;
 import com.f1predict.prediction.service.PredictionService;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -39,6 +41,13 @@ public class PredictionController {
             @RequestHeader("X-User-Id") UUID userId,
             @Valid @RequestBody SubmitPredictionRequest request) {
         return predictionService.updatePrediction(userId, raceId, request);
+    }
+
+    @GetMapping("/{raceId}/internal/all")
+    public List<InternalPredictionResponse> getAllLocked(
+            @PathVariable @Pattern(regexp = "^[A-Z0-9_-]{3,20}$") String raceId,
+            @RequestParam(defaultValue = "RACE") @Pattern(regexp = "RACE|SPRINT") String sessionType) {
+        return predictionService.getLockedPredictions(raceId, sessionType);
     }
 
     @PostMapping("/{raceId}/bets")

--- a/services/prediction-service/src/main/java/com/f1predict/prediction/dto/InternalPredictionResponse.java
+++ b/services/prediction-service/src/main/java/com/f1predict/prediction/dto/InternalPredictionResponse.java
@@ -1,0 +1,15 @@
+package com.f1predict.prediction.dto;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public record InternalPredictionResponse(
+    UUID userId,
+    String sessionType,
+    List<String> rankedDriverCodes,
+    List<InternalBetData> bets,
+    Instant updatedAt
+) {
+    public record InternalBetData(String betType, int stake, String betValue) {}
+}

--- a/services/prediction-service/src/main/java/com/f1predict/prediction/repository/PredictionRepository.java
+++ b/services/prediction-service/src/main/java/com/f1predict/prediction/repository/PredictionRepository.java
@@ -10,4 +10,5 @@ public interface PredictionRepository extends JpaRepository<Prediction, UUID> {
     Optional<Prediction> findByUserIdAndRaceIdAndSessionType(UUID userId, String raceId, String sessionType);
     List<Prediction> findByRaceIdAndSessionType(String raceId, String sessionType);
     List<Prediction> findByRaceId(String raceId);
+    List<Prediction> findByRaceIdAndSessionTypeAndLockedTrue(String raceId, String sessionType);
 }

--- a/services/prediction-service/src/main/java/com/f1predict/prediction/service/PredictionService.java
+++ b/services/prediction-service/src/main/java/com/f1predict/prediction/service/PredictionService.java
@@ -1,8 +1,10 @@
 package com.f1predict.prediction.service;
 
+import com.f1predict.prediction.client.F1DataClient;
 import com.f1predict.prediction.client.ScoringClient;
 import com.f1predict.prediction.dto.BonusBetRequest;
 import com.f1predict.prediction.dto.BonusBetResponse;
+import com.f1predict.prediction.dto.InternalPredictionResponse;
 import com.f1predict.prediction.dto.PredictionResponse;
 import com.f1predict.prediction.dto.SubmitPredictionRequest;
 import com.f1predict.prediction.model.BonusBet;
@@ -25,18 +27,30 @@ public class PredictionService {
     private final PredictionRepository predictionRepository;
     private final BonusBetRepository bonusBetRepository;
     private final ScoringClient scoringClient;
+    private final F1DataClient f1DataClient;
 
     public PredictionService(PredictionRepository predictionRepository,
                              BonusBetRepository bonusBetRepository,
-                             ScoringClient scoringClient) {
+                             ScoringClient scoringClient,
+                             F1DataClient f1DataClient) {
         this.predictionRepository = predictionRepository;
         this.bonusBetRepository = bonusBetRepository;
         this.scoringClient = scoringClient;
+        this.f1DataClient = f1DataClient;
+    }
+
+    private void checkDeadline(String raceId) {
+        Instant deadline = f1DataClient.getQualifyingDeadline(raceId);
+        if (deadline != null && Instant.now().isAfter(deadline)) {
+            throw new IllegalStateException("Prediction deadline has passed");
+        }
     }
 
     @Transactional
     public PredictionResponse submitPrediction(UUID userId, String raceId, SubmitPredictionRequest req) {
         String sessionType = req.sessionType() != null ? req.sessionType() : "RACE";
+
+        checkDeadline(raceId);
 
         predictionRepository.findByUserIdAndRaceIdAndSessionType(userId, raceId, sessionType)
             .ifPresent(p -> { throw new IllegalStateException("Prediction already submitted"); });
@@ -58,6 +72,8 @@ public class PredictionService {
     public PredictionResponse updatePrediction(UUID userId, String raceId, SubmitPredictionRequest req) {
         String sessionType = req.sessionType() != null ? req.sessionType() : "RACE";
 
+        checkDeadline(raceId);
+
         Prediction prediction = predictionRepository
             .findByUserIdAndRaceIdAndSessionType(userId, raceId, sessionType)
             .orElseThrow(() -> new NoSuchElementException("No prediction found for this race"));
@@ -78,6 +94,7 @@ public class PredictionService {
     @Transactional
     public BonusBetResponse submitBet(UUID userId, String raceId, String sessionType, UUID leagueId, BonusBetRequest req) {
         String sType = sessionType != null ? sessionType : "RACE";
+        checkDeadline(raceId);
         Prediction prediction = predictionRepository
             .findByUserIdAndRaceIdAndSessionType(userId, raceId, sType)
             .orElseThrow(() -> new NoSuchElementException("No prediction found for this race"));
@@ -98,6 +115,25 @@ public class PredictionService {
         bet.setBetValue(req.betValue());
         BonusBet saved = bonusBetRepository.save(bet);
         return new BonusBetResponse(saved.getId(), saved.getBetType(), saved.getStake(), saved.getBetValue());
+    }
+
+    public List<InternalPredictionResponse> getLockedPredictions(String raceId, String sessionType) {
+        return predictionRepository.findByRaceIdAndSessionTypeAndLockedTrue(raceId, sessionType)
+            .stream()
+            .map(p -> new InternalPredictionResponse(
+                p.getUserId(),
+                p.getSessionType(),
+                p.getEntries().stream()
+                    .sorted(java.util.Comparator.comparingInt(PredictionEntry::getPosition))
+                    .map(PredictionEntry::getDriverCode)
+                    .toList(),
+                p.getBonusBets().stream()
+                    .map(b -> new InternalPredictionResponse.InternalBetData(
+                        b.getBetType().name(), b.getStake(), b.getBetValue()))
+                    .toList(),
+                p.getUpdatedAt()
+            ))
+            .toList();
     }
 
     private List<PredictionEntry> buildEntries(List<String> driverCodes, Prediction prediction) {

--- a/services/prediction-service/src/main/resources/application.yml
+++ b/services/prediction-service/src/main/resources/application.yml
@@ -24,3 +24,4 @@ spring:
 
 services:
   scoring-url: http://localhost:8084
+  f1data-url: http://localhost:8085

--- a/services/prediction-service/src/test/java/com/f1predict/prediction/PredictionControllerIntegrationTest.java
+++ b/services/prediction-service/src/test/java/com/f1predict/prediction/PredictionControllerIntegrationTest.java
@@ -1,8 +1,10 @@
 package com.f1predict.prediction;
 
+import com.f1predict.prediction.client.F1DataClient;
 import com.f1predict.prediction.repository.PredictionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -16,6 +18,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.time.Instant;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,8 +42,8 @@ class PredictionControllerIntegrationTest {
         registry.add("spring.rabbitmq.port", () -> "5672");
     }
 
-    @MockBean
-    RabbitTemplate rabbitTemplate;
+    @MockBean RabbitTemplate rabbitTemplate;
+    @MockBean F1DataClient f1DataClient;
 
     @Autowired MockMvc mockMvc;
     @Autowired PredictionRepository predictionRepository;
@@ -213,6 +216,72 @@ class PredictionControllerIntegrationTest {
                     {"rankedDriverCodes":["VER","HAM","LEC","NOR","PIA","RUS","ALO","SAI","GAS","HUL"]}
                     """))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void submit_beforeDeadline_isAllowed() throws Exception {
+        Mockito.when(f1DataClient.getQualifyingDeadline(raceId))
+            .thenReturn(Instant.now().plusSeconds(3600));
+
+        mockMvc.perform(post("/predictions/" + raceId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-User-Id", userId.toString())
+                .content("""
+                    {"rankedDriverCodes":["VER","HAM","LEC","NOR","PIA","RUS","ALO","SAI","GAS","HUL"]}
+                    """))
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    void submit_afterDeadline_returns409() throws Exception {
+        Mockito.when(f1DataClient.getQualifyingDeadline(raceId))
+            .thenReturn(Instant.now().minusSeconds(1));
+
+        mockMvc.perform(post("/predictions/" + raceId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-User-Id", userId.toString())
+                .content("""
+                    {"rankedDriverCodes":["VER","HAM","LEC","NOR","PIA","RUS","ALO","SAI","GAS","HUL"]}
+                    """))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void update_afterDeadline_returns409() throws Exception {
+        // First submit before deadline
+        Mockito.when(f1DataClient.getQualifyingDeadline(raceId)).thenReturn(null); // no deadline
+        mockMvc.perform(post("/predictions/" + raceId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-User-Id", userId.toString())
+                .content("""
+                    {"rankedDriverCodes":["VER","HAM","LEC","NOR","PIA","RUS","ALO","SAI","GAS","HUL"]}
+                    """))
+            .andExpect(status().isCreated());
+
+        // Now deadline has passed
+        Mockito.when(f1DataClient.getQualifyingDeadline(raceId))
+            .thenReturn(Instant.now().minusSeconds(1));
+
+        mockMvc.perform(put("/predictions/" + raceId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-User-Id", userId.toString())
+                .content("""
+                    {"rankedDriverCodes":["HAM","VER","LEC","NOR","PIA","RUS","ALO","SAI","GAS","HUL"]}
+                    """))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void submit_deadlineNull_failsOpen() throws Exception {
+        Mockito.when(f1DataClient.getQualifyingDeadline(raceId)).thenReturn(null);
+
+        mockMvc.perform(post("/predictions/" + raceId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-User-Id", userId.toString())
+                .content("""
+                    {"rankedDriverCodes":["VER","HAM","LEC","NOR","PIA","RUS","ALO","SAI","GAS","HUL"]}
+                    """))
+            .andExpect(status().isCreated());
     }
 
     @Test

--- a/services/scoring-service/src/main/java/com/f1predict/scoring/client/F1DataClient.java
+++ b/services/scoring-service/src/main/java/com/f1predict/scoring/client/F1DataClient.java
@@ -1,0 +1,48 @@
+package com.f1predict.scoring.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.time.Instant;
+
+@Component
+public class F1DataClient {
+
+    private static final Logger log = LoggerFactory.getLogger(F1DataClient.class);
+
+    private final RestClient restClient;
+
+    public F1DataClient(@Value("${services.f1data-url}") String f1dataUrl) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(2000);
+        factory.setReadTimeout(3000);
+        this.restClient = RestClient.builder()
+            .baseUrl(f1dataUrl)
+            .requestFactory(factory)
+            .build();
+    }
+
+    record DeadlineResponse(String raceId, Instant qualifyingDeadline) {}
+
+    /**
+     * Returns the qualifying deadline for the race, or null if the race is unknown
+     * or the F1 data service is unavailable (fail open — caller should score everything).
+     */
+    public Instant getQualifyingDeadline(String raceId) {
+        try {
+            DeadlineResponse response = restClient.get()
+                .uri("/races/{raceId}/deadline", raceId)
+                .retrieve()
+                .body(DeadlineResponse.class);
+            return response != null ? response.qualifyingDeadline() : null;
+        } catch (RestClientException e) {
+            log.warn("F1 data service unavailable for deadline check — scoring all predictions. raceId={}", raceId);
+            return null;
+        }
+    }
+}

--- a/services/scoring-service/src/main/java/com/f1predict/scoring/dto/PredictionData.java
+++ b/services/scoring-service/src/main/java/com/f1predict/scoring/dto/PredictionData.java
@@ -1,5 +1,6 @@
 package com.f1predict.scoring.dto;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -7,5 +8,6 @@ public record PredictionData(
     UUID userId,
     String sessionType,
     List<String> rankedDriverCodes,
-    List<BetData> bets
+    List<BetData> bets,
+    Instant updatedAt
 ) {}

--- a/services/scoring-service/src/main/java/com/f1predict/scoring/service/ScoringOrchestrator.java
+++ b/services/scoring-service/src/main/java/com/f1predict/scoring/service/ScoringOrchestrator.java
@@ -2,6 +2,7 @@ package com.f1predict.scoring.service;
 
 import com.f1predict.common.events.RaceResultFinalEvent;
 import com.f1predict.common.events.SessionCompleteEvent;
+import com.f1predict.scoring.client.F1DataClient;
 import com.f1predict.scoring.client.LeagueClient;
 import com.f1predict.scoring.client.PredictionClient;
 import com.f1predict.scoring.dto.*;
@@ -27,6 +28,7 @@ public class ScoringOrchestrator {
     private static final Logger log = LoggerFactory.getLogger(ScoringOrchestrator.class);
 
     private final PredictionClient predictionClient;
+    private final F1DataClient f1DataClient;
     private final LeagueClient leagueClient;
     private final ProximityScoreEngine proximityEngine;
     private final BonusBetScoreEngine bonusBetEngine;
@@ -35,6 +37,7 @@ public class ScoringOrchestrator {
     private final LeagueStandingRepository standingRepository;
 
     public ScoringOrchestrator(PredictionClient predictionClient,
+                                F1DataClient f1DataClient,
                                 LeagueClient leagueClient,
                                 ProximityScoreEngine proximityEngine,
                                 BonusBetScoreEngine bonusBetEngine,
@@ -42,6 +45,7 @@ public class ScoringOrchestrator {
                                 RaceScoreRepository raceScoreRepository,
                                 LeagueStandingRepository standingRepository) {
         this.predictionClient = predictionClient;
+        this.f1DataClient = f1DataClient;
         this.leagueClient = leagueClient;
         this.proximityEngine = proximityEngine;
         this.bonusBetEngine = bonusBetEngine;
@@ -68,11 +72,14 @@ public class ScoringOrchestrator {
         RaceResultData result = buildResultData(rawResults, fastestLapDriver, safetyCarsDeployed,
                 partialDistance, cancelled);
 
-        List<PredictionData> predictions = predictionClient.getPredictions(raceId, sessionTypeStr);
-        if (predictions.isEmpty()) {
+        List<PredictionData> allPredictions = predictionClient.getPredictions(raceId, sessionTypeStr);
+        if (allPredictions.isEmpty()) {
             log.info("No predictions found for race {} {} — nothing to score", raceId, sessionTypeStr);
             return;
         }
+
+        Instant deadline = f1DataClient.getQualifyingDeadline(raceId);
+        List<PredictionData> predictions = filterLatePredictions(allPredictions, deadline, raceId);
 
         // Collect distinct league IDs from: (a) all known standings, (b) prior scores for this race
         Set<UUID> leagueIds = new LinkedHashSet<>(standingRepository.findDistinctLeagueIds());
@@ -149,6 +156,24 @@ public class ScoringOrchestrator {
 
         raceScoreRepository.saveAll(scores);
         standingsService.recalculate(leagueId, raceId, sessionType);
+    }
+
+    /**
+     * Returns predictions that were submitted before the qualifying deadline.
+     * Predictions with a null updatedAt or a null deadline are always kept (fail open).
+     */
+    private List<PredictionData> filterLatePredictions(List<PredictionData> predictions,
+                                                        Instant deadline,
+                                                        String raceId) {
+        if (deadline == null) return predictions;
+        List<PredictionData> valid = predictions.stream()
+            .filter(p -> p.updatedAt() == null || !p.updatedAt().isAfter(deadline))
+            .toList();
+        int dropped = predictions.size() - valid.size();
+        if (dropped > 0) {
+            log.warn("Dropping {} late prediction(s) for race {} (deadline={})", dropped, raceId, deadline);
+        }
+        return valid;
     }
 
     private RaceResultData buildResultData(List<RaceResultFinalEvent.DriverResult> raw,

--- a/services/scoring-service/src/main/resources/application.yml
+++ b/services/scoring-service/src/main/resources/application.yml
@@ -25,3 +25,4 @@ spring:
 services:
   prediction-url: http://localhost:8082
   league-url: http://localhost:8083
+  f1data-url: http://localhost:8085

--- a/services/scoring-service/src/test/java/com/f1predict/scoring/ScoringOrchestratorTest.java
+++ b/services/scoring-service/src/test/java/com/f1predict/scoring/ScoringOrchestratorTest.java
@@ -2,6 +2,7 @@ package com.f1predict.scoring;
 
 import com.f1predict.common.events.RaceResultFinalEvent;
 import com.f1predict.common.events.SessionCompleteEvent;
+import com.f1predict.scoring.client.F1DataClient;
 import com.f1predict.scoring.client.LeagueClient;
 import com.f1predict.scoring.client.PredictionClient;
 import com.f1predict.scoring.dto.*;
@@ -19,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,6 +34,7 @@ import static org.mockito.Mockito.*;
 class ScoringOrchestratorTest {
 
     @Mock PredictionClient predictionClient;
+    @Mock F1DataClient f1DataClient;
     @Mock LeagueClient leagueClient;
     @Mock RaceScoreRepository raceScoreRepository;
     @Mock LeagueStandingRepository standingRepository;
@@ -52,12 +55,13 @@ class ScoringOrchestratorTest {
     @BeforeEach
     void setUp() {
         orchestrator = new ScoringOrchestrator(
-            predictionClient, leagueClient,
+            predictionClient, f1DataClient, leagueClient,
             new ProximityScoreEngine(), new BonusBetScoreEngine(),
             standingsService, raceScoreRepository, standingRepository
         );
 
-        // Default: one league, one member, standard config, no existing score
+        // Default: no deadline (fail open), one league, one member, standard config, no existing score
+        when(f1DataClient.getQualifyingDeadline(anyString())).thenReturn(null);
         when(standingRepository.findDistinctLeagueIds()).thenReturn(List.of(leagueId));
         when(raceScoreRepository.findDistinctLeagueIdsByRaceId(anyString())).thenReturn(List.of());
         when(leagueClient.getMembers(leagueId)).thenReturn(List.of(new LeagueMemberData(userId, 0)));
@@ -71,7 +75,7 @@ class ScoringOrchestratorTest {
     void partialDistance_halvesAllPoints() {
         // VER predicted 1st, actually 1st → 10 topN pts; no bets
         when(predictionClient.getPredictions("2026-01", "RACE")).thenReturn(List.of(
-            new PredictionData(userId, "RACE", List.of("VER"), List.of())
+            new PredictionData(userId, "RACE", List.of("VER"), List.of(), null)
         ));
 
         orchestrator.scoreRace("2026-01", SessionCompleteEvent.SessionType.RACE,
@@ -93,7 +97,7 @@ class ScoringOrchestratorTest {
         // Losing FASTEST_LAP bet: stake=50, loss=-50; halved = -25
         when(predictionClient.getPredictions("2026-01", "RACE")).thenReturn(List.of(
             new PredictionData(userId, "RACE", List.of("VER"),
-                List.of(new BetData("FASTEST_LAP", 50, "HAM")))  // HAM wrong, VER is fastest
+                List.of(new BetData("FASTEST_LAP", 50, "HAM")), null)  // HAM wrong, VER is fastest
         ));
 
         orchestrator.scoreRace("2026-01", SessionCompleteEvent.SessionType.RACE,
@@ -112,7 +116,7 @@ class ScoringOrchestratorTest {
     @Test
     void cancelledRace_storesZeroPointsForAllUsers() {
         when(predictionClient.getPredictions("2026-02", "RACE")).thenReturn(List.of(
-            new PredictionData(userId, "RACE", List.of("VER"), List.of())
+            new PredictionData(userId, "RACE", List.of("VER"), List.of(), null)
         ));
 
         orchestrator.scoreRace("2026-02", SessionCompleteEvent.SessionType.RACE,
@@ -132,7 +136,7 @@ class ScoringOrchestratorTest {
     void fastestLapBet_correctDriver_wins() {
         when(predictionClient.getPredictions("2026-03", "RACE")).thenReturn(List.of(
             new PredictionData(userId, "RACE", List.of(),
-                List.of(new BetData("FASTEST_LAP", 50, "VER")))
+                List.of(new BetData("FASTEST_LAP", 50, "VER")), null)
         ));
 
         orchestrator.scoreRace("2026-03", SessionCompleteEvent.SessionType.RACE,
@@ -150,7 +154,7 @@ class ScoringOrchestratorTest {
     void safetyCar_correctCount_wins() {
         when(predictionClient.getPredictions("2026-04", "RACE")).thenReturn(List.of(
             new PredictionData(userId, "RACE", List.of(),
-                List.of(new BetData("SC_COUNT", 25, "2")))
+                List.of(new BetData("SC_COUNT", 25, "2")), null)
         ));
 
         orchestrator.scoreRace("2026-04", SessionCompleteEvent.SessionType.RACE,
@@ -169,7 +173,7 @@ class ScoringOrchestratorTest {
         when(raceScoreRepository.findDistinctLeagueIdsByRaceId(anyString())).thenReturn(List.of());
         // predictions are fetched before league discovery is checked, but scoreLeague is never called
         when(predictionClient.getPredictions(anyString(), anyString())).thenReturn(
-            List.of(new PredictionData(userId, "RACE", List.of("VER"), List.of()))
+            List.of(new PredictionData(userId, "RACE", List.of("VER"), List.of(), null))
         );
 
         orchestrator.scoreRace("2026-05", SessionCompleteEvent.SessionType.RACE,
@@ -177,5 +181,37 @@ class ScoringOrchestratorTest {
 
         verify(leagueClient, never()).getMembers(any());
         verify(raceScoreRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void latePrediction_isDropped_zeroScoreNotStored() {
+        Instant deadline = Instant.now().minusSeconds(300);
+        when(f1DataClient.getQualifyingDeadline("2026-06")).thenReturn(deadline);
+
+        UUID onTimeUser = UUID.randomUUID();
+        UUID lateUser = UUID.randomUUID();
+        when(leagueClient.getMembers(leagueId)).thenReturn(List.of(
+            new LeagueMemberData(onTimeUser, 0),
+            new LeagueMemberData(lateUser, 0)
+        ));
+
+        when(predictionClient.getPredictions("2026-06", "RACE")).thenReturn(List.of(
+            new PredictionData(onTimeUser, "RACE", List.of("VER"), List.of(),
+                deadline.minusSeconds(60)),   // submitted before deadline — valid
+            new PredictionData(lateUser, "RACE", List.of("VER"), List.of(),
+                deadline.plusSeconds(10))     // submitted after deadline — dropped
+        ));
+
+        orchestrator.scoreRace("2026-06", SessionCompleteEvent.SessionType.RACE,
+            List.of(new RaceResultFinalEvent.DriverResult("VER", 1, RaceResultFinalEvent.DriverStatus.CLASSIFIED)),
+            null, 0, false, false, 1);
+
+        ArgumentCaptor<List<RaceScore>> captor = ArgumentCaptor.forClass(List.class);
+        verify(raceScoreRepository).saveAll(captor.capture());
+        List<RaceScore> scores = captor.getValue();
+
+        // Only the on-time user should be scored
+        assertThat(scores).hasSize(1);
+        assertThat(scores.get(0).getUserId()).isEqualTo(onTimeUser);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `qualifying_deadline` column to `races` table (F1 data service Flyway V2) and exposes it via `GET /races/{raceId}/deadline`
- Prediction service checks deadline before submit, update, and bet endpoints — returns 409 if past deadline; fails open if F1 data service is unavailable
- Adds `GET /predictions/{raceId}/internal/all` endpoint for the scoring service, returning locked predictions with `updatedAt`
- Scoring service drops predictions with `updatedAt > qualifyingDeadline` before scoring; fails open if deadline is unknown

## Test plan
- [ ] `submit_beforeDeadline_isAllowed` — 201 when deadline is in the future
- [ ] `submit_afterDeadline_returns409` — 409 when deadline has passed
- [ ] `update_afterDeadline_returns409` — 409 on PUT when deadline has passed
- [ ] `submit_deadlineNull_failsOpen` — 201 when F1 data service returns null (unavailable)
- [ ] `latePrediction_isDropped_zeroScoreNotStored` — late prediction excluded from scoring, only on-time user scored
- [ ] All existing scoring unit tests pass with `null` updatedAt (backward compatible)

Closes #146