### PR TITLE
fix(deploy): retry smoke test — Spring Boot needs 2-3 min to start

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,18 +191,25 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           PROD_BASE_URL: ${{ vars.PROD_BASE_URL }}
         run: |
-          echo "Waiting 30s for services to stabilise..."
-          sleep 30
-          check() {
+          # Spring Boot services can take 2-3 min to start on cold deploy.
+          # Retry up to 10 times with 20s gaps (max 3m20s wait).
+          check_with_retry() {
             local label=$1 url=$2
-            local status
-            status=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 "$url")
-            echo "  $label → HTTP $status"
-            [ "$status" != "000" ] && ! echo "$status" | grep -qE "^50[234]$"
+            local status attempt
+            for attempt in $(seq 1 10); do
+              status=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 "$url")
+              echo "  $label → HTTP $status (attempt $attempt/10)"
+              # 000 = connection error, 50[2-4] = gateway/upstream errors worth retrying
+              if [ "$status" = "000" ] || echo "$status" | grep -qE "^50[234]$"; then
+                [ "$attempt" -lt 10 ] && sleep 20 || return 1
+              else
+                return 0
+              fi
+            done
           }
-          check "auth"          "${PROD_BASE_URL}/auth/register"          || exit 1
-          check "f1data"        "${PROD_BASE_URL}/f1/calendar/current"    || exit 1
-          check "analytics"     "${PROD_BASE_URL}/analytics/participation" || exit 1
+          check_with_retry "auth"      "${PROD_BASE_URL}/auth/register"          || exit 1
+          check_with_retry "f1data"    "${PROD_BASE_URL}/f1/calendar/current"    || exit 1
+          check_with_retry "analytics" "${PROD_BASE_URL}/analytics/participation" || exit 1
 
   # ── 3. Notify on failure ──────────────────────────────────────────────────
   notify-failure:


### PR DESCRIPTION
## Summary
- Replaces the fixed 30s sleep with a retry loop (10 attempts × 20s = up to 3m20s wait)
- Retries on `000` (connection refused) and `50[2-4]` (gateway errors while Spring Boot starts)
- Accepts any other status (401, 404, 405, 200…) as "service is alive"
- Smoke test now passes even on cold deploys where Spring Boot takes 2-3 min

## Context
PR #151 fixed JWT_SECRET (auth-service now starts successfully). The smoke test still failed because it checked at 30s when auth-service was still initialising (HTTP 502). The API is verified working: `POST /auth/register` returns HTTP 201 with a valid JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)