### PR TITLE
feat(deploy): serve pitwall.guru launch page + functional smoke tests

### DIFF
--- a/.github/deploy/nginx-pitwall.conf
+++ b/.github/deploy/nginx-pitwall.conf
@@ -1,0 +1,27 @@
+# nginx config for pitwall.guru — managed by deploy.yml, do not edit on server
+# Serves the Pitwall launch page (Astro static) and proxies API paths to api-gateway
+
+server {
+    listen 80;
+    server_name pitwall.guru www.pitwall.guru;
+
+    root /opt/f1predict/web-static;
+    index index.html;
+
+    # Proxy all backend API paths to api-gateway
+    location ~ ^/(auth|f1|predictions|leagues|scores|notifications|analytics|ws)/ {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 60s;
+    }
+
+    # Serve static launch page — SPA fallback for client-side routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,9 +119,10 @@ jobs:
             -e "s|IMAGE_TAG|sha-${SHA::7}|g" \
             .github/deploy/docker-compose.prod.yml.tpl > docker-compose.prod.yml
 
-      - name: Copy compose files to server
+      - name: Copy compose and nginx files to server
         run: |
           scp docker-compose.yml docker-compose.prod.yml \
+            .github/deploy/nginx-pitwall.conf \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/f1predict/
 
       - name: Bootstrap server .env (generate secrets if missing)
@@ -186,20 +187,44 @@ jobs:
             done
           '
 
-      - name: Post-deploy smoke test
+      - name: Sync launch page and update nginx
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh ${DEPLOY_USER}@${DEPLOY_HOST} '
+            set -e
+            # Pull latest pitwall-launch static site (gh-pages branch)
+            if [ -d /opt/f1predict/web-static/.git ]; then
+              git -C /opt/f1predict/web-static fetch --quiet origin gh-pages
+              git -C /opt/f1predict/web-static reset --hard origin/gh-pages
+            else
+              git clone --quiet --single-branch --branch gh-pages \
+                https://github.com/dhuelin/pitwall-launch.git \
+                /opt/f1predict/web-static
+            fi
+            echo "  launch page: synced ($(ls /opt/f1predict/web-static | wc -l) files)"
+
+            # Install nginx config and reload
+            sudo cp /opt/f1predict/nginx-pitwall.conf /etc/nginx/sites-available/pitwall
+            sudo nginx -t
+            sudo systemctl reload nginx
+            echo "  nginx: reloaded"
+          '
+
+      - name: Post-deploy smoke test (functional)
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           PROD_BASE_URL: ${{ vars.PROD_BASE_URL }}
+          SMOKE_RUN_ID: ${{ github.run_id }}
         run: |
-          # Spring Boot services can take 2-3 min to start on cold deploy.
-          # Retry up to 10 times with 20s gaps (max 3m20s wait).
-          check_with_retry() {
+          # Helper: retry a plain HTTP check (for gateway/startup errors)
+          wait_for_service() {
             local label=$1 url=$2
             local status attempt
             for attempt in $(seq 1 10); do
               status=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 "$url")
               echo "  $label → HTTP $status (attempt $attempt/10)"
-              # 000 = connection error, 50[2-4] = gateway/upstream errors worth retrying
               if [ "$status" = "000" ] || echo "$status" | grep -qE "^50[234]$"; then
                 [ "$attempt" -lt 10 ] && sleep 20 || return 1
               else
@@ -207,9 +232,42 @@ jobs:
               fi
             done
           }
-          check_with_retry "auth"      "${PROD_BASE_URL}/auth/register"          || exit 1
-          check_with_retry "f1data"    "${PROD_BASE_URL}/f1/calendar/current"    || exit 1
-          check_with_retry "analytics" "${PROD_BASE_URL}/analytics/participation" || exit 1
+
+          echo "── 1. Launch page ───────────────────────────────"
+          PAGE_STATUS=$(curl -s -o /tmp/page.html -w "%{http_code}" --connect-timeout 10 "https://pitwall.guru")
+          echo "  pitwall.guru → HTTP $PAGE_STATUS"
+          [ "$PAGE_STATUS" = "200" ] || { echo "FAIL: launch page not served"; exit 1; }
+          grep -qi "pitwall" /tmp/page.html || { echo "FAIL: page HTML missing Pitwall content"; exit 1; }
+          echo "  content: OK"
+
+          echo "── 2. Auth service — wait for Spring Boot ───────"
+          wait_for_service "auth-gateway" "${PROD_BASE_URL}/auth/register" || exit 1
+
+          echo "── 3. Auth service — functional register + token ─"
+          SMOKE_EMAIL="smoke-${SMOKE_RUN_ID}@pitwall.guru"
+          REG=$(curl -s -X POST "${PROD_BASE_URL}/auth/register" \
+            -H "Content-Type: application/json" \
+            -d "{\"email\":\"${SMOKE_EMAIL}\",\"password\":\"SmokeTest1!\",\"username\":\"smoke${SMOKE_RUN_ID}\"}")
+          TOKEN=$(echo "$REG" | grep -o '"accessToken":"[^"]*"' | sed 's/"accessToken":"//;s/"//')
+          if [ -z "$TOKEN" ]; then
+            echo "  register failed, body: $REG"
+            exit 1
+          fi
+          echo "  register → token acquired (${#TOKEN} chars)"
+
+          echo "── 4. F1 data service — authenticated call ───────"
+          F1_STATUS=$(curl -s -o /tmp/f1.json -w "%{http_code}" --connect-timeout 10 \
+            -H "Authorization: Bearer $TOKEN" "${PROD_BASE_URL}/f1/calendar/current")
+          echo "  f1data → HTTP $F1_STATUS"
+          echo "$F1_STATUS" | grep -qE "^(200|404)$" || { echo "FAIL: f1data returned $F1_STATUS"; exit 1; }
+
+          echo "── 5. Analytics service — authenticated call ─────"
+          AN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 \
+            -H "Authorization: Bearer $TOKEN" "${PROD_BASE_URL}/analytics/participation")
+          echo "  analytics → HTTP $AN_STATUS"
+          echo "$AN_STATUS" | grep -qE "^(200|404)$" || { echo "FAIL: analytics returned $AN_STATUS"; exit 1; }
+
+          echo "All smoke tests passed ✓"
 
   # ── 3. Notify on failure ──────────────────────────────────────────────────
   notify-failure:


### PR DESCRIPTION
## Summary
- **nginx-pitwall.conf** (new): serves Astro static site at `/`, proxies all API paths (`/auth`, `/f1`, `/predictions`, `/leagues`, `/scores`, `/notifications`, `/analytics`, `/ws`) to api-gateway on port 8080
- **Sync launch page** deploy step: git-clones `dhuelin/pitwall-launch` gh-pages onto VPS at `/opt/f1predict/web-static/`, installs nginx config with `sudo`, reloads nginx
- **Functional smoke tests** replace availability-only checks:
  1. `pitwall.guru` → HTTP 200 + HTML contains "pitwall"
  2. `POST /auth/register` → JWT `accessToken` acquired
  3. `GET /f1/calendar/current` with `Bearer` token → 200 or 404 (not 5xx/401)
  4. `GET /analytics/participation` with `Bearer` token → 200 or 404

## Notes
- Requires `NOPASSWD` sudo for `cp`, `nginx -t`, `systemctl reload nginx` on the deploy user

## Test plan
- [ ] `pitwall.guru` shows the Pitwall launch page
- [ ] Smoke test all 5 steps pass green

🤖 Generated with [Claude Code](https://claude.com/claude-code)