### PR TITLE
fix(deploy): serve pitwall.guru launch page via web-static Docker container

### DIFF
--- a/.github/deploy/docker-compose.prod.yml.tpl
+++ b/.github/deploy/docker-compose.prod.yml.tpl
@@ -94,6 +94,14 @@ services:
     image: IMAGE_PREFIX/analytics-service:IMAGE_TAG
     restart: unless-stopped
 
-  # Web frontend is served by Cloudflare Pages in production — exclude it here
+  # Pitwall launch page — served from nginx:alpine mounting the pitwall-launch gh-pages clone
+  # The api-gateway routes /** to this container so pitwall.guru/ shows the landing page
+  web-static:
+    image: nginx:alpine
+    restart: unless-stopped
+    volumes:
+      - ./web-static:/usr/share/nginx/html:ro
+
+  # Full web app is dev-only (React/Vite build served locally); excluded from VPS
   web:
     profiles: ["dev"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,10 +119,9 @@ jobs:
             -e "s|IMAGE_TAG|sha-${SHA::7}|g" \
             .github/deploy/docker-compose.prod.yml.tpl > docker-compose.prod.yml
 
-      - name: Copy compose and nginx files to server
+      - name: Copy compose files to server
         run: |
           scp docker-compose.yml docker-compose.prod.yml \
-            .github/deploy/nginx-pitwall.conf \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/f1predict/
 
       - name: Bootstrap server .env (generate secrets if missing)
@@ -158,10 +157,12 @@ jobs:
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose -f docker-compose.yml -f docker-compose.prod.yml pull \
               api-gateway auth-service prediction-service league-service \
-              scoring-service f1-data-service notification-service analytics-service
+              scoring-service f1-data-service notification-service analytics-service \
+              web-static
             docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --remove-orphans \
               api-gateway auth-service prediction-service league-service \
-              scoring-service f1-data-service notification-service analytics-service
+              scoring-service f1-data-service notification-service analytics-service \
+              web-static
             docker image prune -f
           '
 
@@ -187,14 +188,14 @@ jobs:
             done
           '
 
-      - name: Sync launch page and update nginx
+      - name: Sync launch page static files
         env:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
           ssh ${DEPLOY_USER}@${DEPLOY_HOST} '
             set -e
-            # Pull latest pitwall-launch static site (gh-pages branch)
+            # Pull latest pitwall-launch gh-pages into the volume mount for web-static container
             if [ -d /opt/f1predict/web-static/.git ]; then
               git -C /opt/f1predict/web-static fetch --quiet origin gh-pages
               git -C /opt/f1predict/web-static reset --hard origin/gh-pages
@@ -204,12 +205,6 @@ jobs:
                 /opt/f1predict/web-static
             fi
             echo "  launch page: synced ($(ls /opt/f1predict/web-static | wc -l) files)"
-
-            # Install nginx config and reload
-            sudo cp /opt/f1predict/nginx-pitwall.conf /etc/nginx/sites-available/pitwall
-            sudo nginx -t
-            sudo systemctl reload nginx
-            echo "  nginx: reloaded"
           '
 
       - name: Post-deploy smoke test (functional)

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -51,6 +51,10 @@ spring:
             - Path=/app/**
           filters:
             - StripPrefix=1
+        - id: web-static
+          uri: http://web-static:80
+          predicates:
+            - Path=/**
   data:
     redis:
       host: ${SPRING_DATA_REDIS_HOST:localhost}


### PR DESCRIPTION
## Summary
Previous approach required `sudo` to update system nginx — deploy user doesn't have passwordless sudo. This switches to a Docker-native approach that needs zero server-side permission changes.

**Architecture:**
```
pitwall.guru/ → nginx:80 → api-gateway:8080 → web-static:80 → Astro index.html
pitwall.guru/auth/* → nginx:80 → api-gateway:8080 → auth-service:8081
```

**Changes:**
- `api-gateway/application.yml`: adds catch-all `/**` route to `web-static:80` (placed last so specific API routes still match first)
- `docker-compose.prod.yml.tpl`: adds `web-static` service (`nginx:alpine` + volume mount `./web-static → /usr/share/nginx/html`)
- `deploy.yml`: adds `web-static` to pull/up service lists; simplifies sync step to just `git clone`/`git pull` (no sudo)

## Test plan
- [ ] `pitwall.guru` returns HTTP 200 with Pitwall HTML
- [ ] `POST https://api.pitwall.guru/auth/register` still returns 201
- [ ] Smoke test all 5 steps pass green

🤖 Generated with [Claude Code](https://claude.com/claude-code)