### PR TITLE
fix(api-gateway): allow unauthenticated access to static web assets

### DIFF
--- a/api-gateway/src/main/java/com/f1predict/gateway/config/JwtGatewayFilter.java
+++ b/api-gateway/src/main/java/com/f1predict/gateway/config/JwtGatewayFilter.java
@@ -19,6 +19,22 @@ import java.nio.charset.StandardCharsets;
 public class JwtGatewayFilter implements GlobalFilter, Ordered {
 
     private static final String USER_ID_HEADER = "X-User-Id";
+
+    /**
+     * API path prefixes that require a valid JWT.
+     * Everything else (auth endpoints, static web assets, etc.) passes through unauthenticated.
+     * Add a prefix here when you add a new protected backend service.
+     */
+    private static final java.util.List<String> PROTECTED_PREFIXES = java.util.List.of(
+        "/f1/",
+        "/predictions/",
+        "/leagues/",
+        "/scores/",
+        "/notifications/",
+        "/analytics/",
+        "/ws/"
+    );
+
     private final SecretKey key;
 
     public JwtGatewayFilter(@Value("${jwt.secret}") String secret) {
@@ -29,8 +45,10 @@ public class JwtGatewayFilter implements GlobalFilter, Ordered {
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         String path = exchange.getRequest().getPath().value();
 
-        // /auth and /auth/** are public — skip JWT validation
-        if (path.equals("/auth") || path.startsWith("/auth/")) {
+        // Only apply JWT validation to known protected API prefixes.
+        // /auth/** and all static web assets pass through without a token.
+        boolean requiresAuth = PROTECTED_PREFIXES.stream().anyMatch(path::startsWith);
+        if (!requiresAuth) {
             return chain.filter(exchange);
         }
 


### PR DESCRIPTION
## Summary
`JwtGatewayFilter` was blocking ALL paths except `/auth/` with HTTP 401, including the static Astro files at `/`, `/_astro/**`, `/favicon.svg` etc. — so `pitwall.guru` returned 401 to every unauthenticated visitor.

**Switch from opt-out to opt-in security:**
- Before: all paths require JWT, `/auth/` is explicitly exempted
- After: only paths in `PROTECTED_PREFIXES` require JWT; everything else passes through

Protected prefixes (require JWT): `/f1/` `/predictions/` `/leagues/` `/scores/` `/notifications/` `/analytics/` `/ws/`

Public (no JWT needed): `/auth/**` + all static assets (`/`, `/_astro/**`, `/favicon.svg`, `/og-image.svg`, etc.)

## Test plan
- [ ] `pitwall.guru` returns HTTP 200 with Pitwall HTML (no auth required)
- [ ] `GET /f1/calendar/current` without token → still returns HTTP 401 ✓
- [ ] Full smoke test (register → token → authenticated API calls) passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)