### PR TITLE
fix(deploy): JWT_SECRET key mismatch between api-gateway and auth-service

### DIFF
--- a/.github/deploy/docker-compose.prod.yml.tpl
+++ b/.github/deploy/docker-compose.prod.yml.tpl
@@ -25,6 +25,8 @@ services:
   api-gateway:
     image: IMAGE_PREFIX/api-gateway:IMAGE_TAG
     restart: unless-stopped
+    environment:
+      JWT_SECRET: "${JWT_SECRET}"
     # In production, only wait for Redis (fast); backend services use service_started
     # to avoid deadlock when Spring Boot takes 2-3 min to pass healthchecks on cold start
     depends_on:


### PR DESCRIPTION
## Summary

- **Root cause of HTTP 401 on `/f1/` and `/analytics/` endpoints**: `api-gateway` was using the hardcoded default `JWT_SECRET` (`change-me-in-production-use-256-bit-key-minimum` from `docker-compose.yml`) while `auth-service` was correctly using the randomly-generated secret from `.env`
- Adding `JWT_SECRET: "${JWT_SECRET}"` to the `api-gateway` service in the production compose overlay ensures both services share the same signing key
- Tokens issued by auth-service will now be verified successfully at the gateway, allowing requests to `/f1/`, `/analytics/`, etc. to pass through

## Test plan

- [ ] Deploy pipeline builds all 8 Docker images
- [ ] All 5 smoke test steps pass:
  1. api-gateway reachable (wait for Spring Boot startup)
  2. pitwall.guru serves Pitwall HTML content (HTTP 200)
  3. `/auth/register` returns JWT token
  4. `/f1/calendar/current` with Bearer token → 200 or 404 (not 401)
  5. `/analytics/participation` with Bearer token → 200 or 404 (not 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)