### PR TITLE
feat: test environment (test.pitwall.guru) + API bug fixes

### DIFF
--- a/.github/deploy/docker-compose.prod.yml.tpl
+++ b/.github/deploy/docker-compose.prod.yml.tpl
@@ -25,6 +25,8 @@ services:
   api-gateway:
     image: IMAGE_PREFIX/api-gateway:IMAGE_TAG
     restart: unless-stopped
+    environment:
+      JWT_SECRET: "${JWT_SECRET}"
     # In production, only wait for Redis (fast); backend services use service_started
     # to avoid deadlock when Spring Boot takes 2-3 min to pass healthchecks on cold start
     depends_on:

--- a/.github/deploy/docker-compose.test.yml.tpl
+++ b/.github/deploy/docker-compose.test.yml.tpl
@@ -1,0 +1,125 @@
+# Test compose override — image tags substituted by deploy.yml, project-name f1predict-test
+# Merge: docker compose --project-name f1predict-test -f docker-compose.yml -f docker-compose.test.yml up
+
+services:
+  # Expose infra on distinct host ports so prod and test coexist on the same VPS
+  postgres:
+    restart: unless-stopped
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U f1predict"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  redis:
+    restart: unless-stopped
+    ports:
+      - "6380:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  rabbitmq:
+    restart: unless-stopped
+    ports:
+      - "5673:5672"
+      - "15673:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
+  api-gateway:
+    image: IMAGE_PREFIX/api-gateway:IMAGE_TAG
+    restart: unless-stopped
+    ports:
+      - "8090:8080"
+    environment:
+      JWT_SECRET: "${JWT_SECRET}"
+      SPRING_DATA_REDIS_HOST: redis
+    # In test, only wait for Redis; backend services use service_started
+    # to avoid deadlock when Spring Boot takes 2-3 min on cold start
+    depends_on:
+      redis:
+        condition: service_healthy
+      auth-service:
+        condition: service_started
+      prediction-service:
+        condition: service_started
+      league-service:
+        condition: service_started
+      scoring-service:
+        condition: service_started
+      f1-data-service:
+        condition: service_started
+      notification-service:
+        condition: service_started
+
+  auth-service:
+    image: IMAGE_PREFIX/auth-service:IMAGE_TAG
+    restart: unless-stopped
+    environment:
+      JWT_SECRET: "${JWT_SECRET}"
+      GOOGLE_CLIENT_ID: "${GOOGLE_CLIENT_ID}"
+      GOOGLE_CLIENT_SECRET: "${GOOGLE_CLIENT_SECRET}"
+      APPLE_CLIENT_ID: "${APPLE_CLIENT_ID}"
+      APPLE_TEAM_ID: "${APPLE_TEAM_ID}"
+      APPLE_KEY_ID: "${APPLE_KEY_ID}"
+
+  prediction-service:
+    image: IMAGE_PREFIX/prediction-service:IMAGE_TAG
+    restart: unless-stopped
+    environment:
+      JWT_SECRET: "${JWT_SECRET}"
+
+  league-service:
+    image: IMAGE_PREFIX/league-service:IMAGE_TAG
+    restart: unless-stopped
+    environment:
+      JWT_SECRET: "${JWT_SECRET}"
+
+  scoring-service:
+    image: IMAGE_PREFIX/scoring-service:IMAGE_TAG
+    restart: unless-stopped
+    environment:
+      JWT_SECRET: "${JWT_SECRET}"
+
+  f1-data-service:
+    image: IMAGE_PREFIX/f1-data-service:IMAGE_TAG
+    restart: unless-stopped
+    environment:
+      JWT_SECRET: "${JWT_SECRET}"
+
+  notification-service:
+    image: IMAGE_PREFIX/notification-service:IMAGE_TAG
+    restart: unless-stopped
+    environment:
+      JWT_SECRET: "${JWT_SECRET}"
+      APNS_TEAM_ID: "${APNS_TEAM_ID}"
+      APNS_KEY_ID: "${APNS_KEY_ID}"
+      APNS_BUNDLE_ID: "${APNS_BUNDLE_ID}"
+      APNS_AUTH_KEY: "${APNS_AUTH_KEY}"
+      APNS_PRODUCTION: "false"
+      FIREBASE_CREDENTIALS_JSON: "${FIREBASE_CREDENTIALS_JSON}"
+
+  analytics-service:
+    image: IMAGE_PREFIX/analytics-service:IMAGE_TAG
+    restart: unless-stopped
+
+  # Pitwall launch page — served from nginx:alpine, volume-mounted from pitwall-launch gh-pages clone
+  web-static:
+    image: nginx:alpine
+    restart: unless-stopped
+    volumes:
+      - ./web-static:/usr/share/nginx/html:ro
+
+  # Full web app is dev-only; excluded from VPS
+  web:
+    profiles: ["dev"]

--- a/.github/deploy/nginx-test.conf
+++ b/.github/deploy/nginx-test.conf
@@ -1,0 +1,27 @@
+# nginx config for test.pitwall.guru — one-time setup, not managed by CI
+# Proxies API paths to test api-gateway on port 8090, serves Pitwall launch page
+
+server {
+    listen 80;
+    server_name test.pitwall.guru;
+
+    root /opt/f1predict-test/web-static;
+    index index.html;
+
+    # Proxy all backend API paths to the test api-gateway
+    location ~ ^/(auth|f1|predictions|leagues|scores|notifications|analytics|ws)/ {
+        proxy_pass http://localhost:8090;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 60s;
+    }
+
+    # Serve static launch page — SPA fallback for client-side routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -268,11 +268,196 @@ jobs:
 
           echo "All smoke tests passed ✓"
 
-  # ── 3. Notify on failure ──────────────────────────────────────────────────
+  # ── 3. Deploy to test environment (test.pitwall.guru) ────────────────────
+  deploy-test:
+    name: Deploy to Test Server
+    runs-on: ubuntu-latest
+    needs: build-images
+    environment: test
+    concurrency:
+      group: test-deploy
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          known_hosts: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+
+      - name: Prepare docker-compose.test.yml
+        env:
+          SHA: ${{ github.sha }}
+          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
+        run: |
+          sed \
+            -e "s|IMAGE_PREFIX|${IMAGE_PREFIX}|g" \
+            -e "s|IMAGE_TAG|sha-${SHA::7}|g" \
+            .github/deploy/docker-compose.test.yml.tpl > docker-compose.test.yml
+
+      - name: Copy compose files to test server
+        run: |
+          ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} 'mkdir -p /opt/f1predict-test'
+          scp docker-compose.yml docker-compose.test.yml \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/f1predict-test/
+
+      - name: Bootstrap test .env (generate secrets if missing)
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh ${DEPLOY_USER}@${DEPLOY_HOST} '
+            touch /opt/f1predict-test/.env
+            cd /opt/f1predict-test
+            if ! grep -q "^JWT_SECRET=.\+" .env 2>/dev/null; then
+              JWT_SECRET=$(openssl rand -base64 48)
+              if grep -q "^JWT_SECRET=" .env 2>/dev/null; then
+                sed -i "s|^JWT_SECRET=.*|JWT_SECRET=${JWT_SECRET}|" .env
+              else
+                echo "JWT_SECRET=${JWT_SECRET}" >> .env
+              fi
+              echo "  JWT_SECRET: generated"
+            else
+              echo "  JWT_SECRET: already set"
+            fi
+          '
+
+      - name: Sync launch page static files (test)
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh ${DEPLOY_USER}@${DEPLOY_HOST} '
+            set -e
+            if [ -d /opt/f1predict-test/web-static/.git ]; then
+              git -C /opt/f1predict-test/web-static fetch --quiet origin gh-pages
+              git -C /opt/f1predict-test/web-static reset --hard origin/gh-pages
+            else
+              git clone --quiet --single-branch --branch gh-pages \
+                https://github.com/dhuelin/pitwall-launch.git \
+                /opt/f1predict-test/web-static
+            fi
+            echo "  launch page: synced ($(ls /opt/f1predict-test/web-static | wc -l) files)"
+          '
+
+      - name: Pull new images and restart test services
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh ${DEPLOY_USER}@${DEPLOY_HOST} '
+            set -e
+            cd /opt/f1predict-test
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker compose --project-name f1predict-test -f docker-compose.yml -f docker-compose.test.yml pull \
+              api-gateway auth-service prediction-service league-service \
+              scoring-service f1-data-service notification-service analytics-service \
+              web-static
+            docker compose --project-name f1predict-test -f docker-compose.yml -f docker-compose.test.yml up -d --remove-orphans \
+              api-gateway auth-service prediction-service league-service \
+              scoring-service f1-data-service notification-service analytics-service \
+              web-static
+            docker image prune -f
+          '
+
+      - name: Initialise test databases (idempotent)
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh ${DEPLOY_USER}@${DEPLOY_HOST} '
+            for i in $(seq 1 12); do
+              docker exec f1predict-test-postgres-1 pg_isready -U f1predict 2>/dev/null && break
+              echo "Waiting for postgres... ($i/12)"
+              sleep 5
+            done
+            for db in auth_db f1data_db prediction_db league_db scoring_db notification_db analytics_db; do
+              docker exec f1predict-test-postgres-1 psql -U f1predict -d postgres -tc \
+                "SELECT 1 FROM pg_database WHERE datname = '"'"'${db}'"'"'" \
+                | grep -q 1 \
+                || docker exec f1predict-test-postgres-1 psql -U f1predict -d postgres -c "CREATE DATABASE ${db};"
+              echo "  ${db}: ready"
+            done
+          '
+
+      - name: Check nginx config for test.pitwall.guru
+        env:
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh ${DEPLOY_USER}@${DEPLOY_HOST} '
+            if [ -f /etc/nginx/sites-enabled/nginx-test.conf ] || \
+               nginx -T 2>/dev/null | grep -q "test.pitwall.guru"; then
+              echo "  nginx: test.pitwall.guru configured ✓"
+            else
+              echo "::warning::nginx not yet configured for test.pitwall.guru."
+              echo "  One-time setup required (run once as root on the VPS):"
+              echo "    sudo cp /opt/f1predict-test/../nginx-test.conf /etc/nginx/sites-enabled/nginx-test.conf"
+              echo "    sudo nginx -t && sudo systemctl reload nginx"
+              echo "  Config file: .github/deploy/nginx-test.conf in this repo"
+              echo "  Until then, test API is available at http://$(hostname -I | awk '"'"'{print $1}'"'"'):8090"
+            fi
+          ' || true
+
+      - name: Post-deploy smoke test (test env)
+        env:
+          TEST_BASE_URL: ${{ vars.TEST_BASE_URL }}
+          SMOKE_RUN_ID: ${{ github.run_id }}
+        run: |
+          wait_for_service() {
+            local label=$1 url=$2
+            local status attempt
+            for attempt in $(seq 1 10); do
+              status=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 "$url")
+              echo "  $label → HTTP $status (attempt $attempt/10)"
+              if [ "$status" = "000" ] || echo "$status" | grep -qE "^50[0234]$"; then
+                [ "$attempt" -lt 10 ] && sleep 20 || return 1
+              else
+                return 0
+              fi
+            done
+          }
+
+          echo "── 1. Wait for test api-gateway (Spring Boot ~2-3 min) ─"
+          wait_for_service "test-gateway" "${TEST_BASE_URL}/auth/register" || exit 1
+
+          echo "── 2. Auth service — functional register + token ──"
+          SMOKE_EMAIL="smoke-test-${SMOKE_RUN_ID}@pitwall.guru"
+          TOKEN=""
+          for reg_attempt in $(seq 1 5); do
+            REG=$(curl -s -X POST "${TEST_BASE_URL}/auth/register" \
+              -H "Content-Type: application/json" \
+              -d "{\"email\":\"${SMOKE_EMAIL}\",\"password\":\"SmokeTest1!\",\"username\":\"smoketest${SMOKE_RUN_ID}\"}")
+            TOKEN=$(echo "$REG" | grep -o '"accessToken":"[^"]*"' | sed 's/"accessToken":"//;s/"//')
+            [ -n "$TOKEN" ] && break
+            echo "  register attempt $reg_attempt failed (retrying in 15s): $(echo "$REG" | head -c 120)"
+            [ "$reg_attempt" -lt 5 ] && sleep 15 || { echo "FAIL: could not obtain token after 5 attempts"; exit 1; }
+          done
+          echo "  register → token acquired (${#TOKEN} chars)"
+
+          echo "── 3. Leagues service — create league ──"
+          LEAGUE=$(curl -s -X POST "${TEST_BASE_URL}/leagues" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -d '{"name":"Smoke Test League","public":true}')
+          LEAGUE_ID=$(echo "$LEAGUE" | grep -o '"id":"[^"]*"' | head -1 | sed 's/"id":"//;s/"//')
+          [ -n "$LEAGUE_ID" ] && echo "  leagues → created (id: ${LEAGUE_ID})" || \
+            echo "  leagues → unexpected response: $(echo "$LEAGUE" | head -c 120)"
+
+          echo "── 4. Analytics service — authenticated call ──"
+          AN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 \
+            -H "Authorization: Bearer $TOKEN" "${TEST_BASE_URL}/analytics/participation")
+          echo "  analytics → HTTP $AN_STATUS"
+          echo "$AN_STATUS" | grep -qE "^(200|404)$" || { echo "FAIL: analytics returned $AN_STATUS"; exit 1; }
+
+          echo "All test smoke tests passed ✓"
+
+  # ── 4. Notify on failure ──────────────────────────────────────────────────
   notify-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest
-    needs: [build-images, deploy]
+    needs: [build-images, deploy, deploy-test]
     if: failure()
     steps:
       - name: Post failure summary

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ yarn-error.log*
 
 # Misc
 .superpowers/
+
+# Claude Code local session files (contain OAuth tokens, never commit)
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/api-gateway/src/main/java/com/f1predict/gateway/config/JwtGatewayFilter.java
+++ b/api-gateway/src/main/java/com/f1predict/gateway/config/JwtGatewayFilter.java
@@ -26,6 +26,7 @@ public class JwtGatewayFilter implements GlobalFilter, Ordered {
      * Add a prefix here when you add a new protected backend service.
      */
     private static final java.util.List<String> PROTECTED_PREFIXES = java.util.List.of(
+        "/auth/me",           // current-user profile — must stay before /auth/ catch-all
         "/f1/",
         "/predictions/",
         "/leagues/",

--- a/services/auth-service/src/main/java/com/f1predict/auth/controller/AuthController.java
+++ b/services/auth-service/src/main/java/com/f1predict/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.f1predict.auth.dto.OAuthCallbackRequest;
 import com.f1predict.auth.dto.RefreshRequest;
 import com.f1predict.auth.dto.RegisterRequest;
 import com.f1predict.auth.dto.ResetPasswordRequest;
+import com.f1predict.auth.dto.UserProfileResponse;
 import com.f1predict.auth.model.OAuthAccount;
 import com.f1predict.auth.service.AppleTokenVerifier;
 import com.f1predict.auth.service.AuthService;
@@ -16,6 +17,8 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/auth")
@@ -73,6 +76,14 @@ public class AuthController {
     public ResponseEntity<Void> resendVerification(@RequestParam String email) {
         authService.resendVerification(email);
         return ResponseEntity.ok().build();
+    }
+
+    // #161 — Current user profile (gateway injects X-User-Id from validated JWT)
+    @GetMapping("/me")
+    public ResponseEntity<UserProfileResponse> me(@RequestHeader("X-User-Id") UUID userId) {
+        return authService.getProfile(userId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 
     @PostMapping("/oauth/google/callback")

--- a/services/auth-service/src/main/java/com/f1predict/auth/dto/UserProfileResponse.java
+++ b/services/auth-service/src/main/java/com/f1predict/auth/dto/UserProfileResponse.java
@@ -1,0 +1,12 @@
+package com.f1predict.auth.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserProfileResponse(
+    UUID id,
+    String email,
+    String username,
+    boolean emailVerified,
+    Instant createdAt
+) {}

--- a/services/auth-service/src/main/java/com/f1predict/auth/service/AuthService.java
+++ b/services/auth-service/src/main/java/com/f1predict/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import com.f1predict.auth.dto.LoginRequest;
 import com.f1predict.auth.dto.RefreshRequest;
 import com.f1predict.auth.dto.RegisterRequest;
 import com.f1predict.auth.dto.ResetPasswordRequest;
+import com.f1predict.auth.dto.UserProfileResponse;
 import com.f1predict.auth.exception.EmailAlreadyExistsException;
 import com.f1predict.auth.exception.InvalidCredentialsException;
 import com.f1predict.auth.exception.InvalidTokenException;
@@ -28,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -64,6 +66,13 @@ public class AuthService {
     }
 
     @Transactional
+    // #161 — Get current user profile by ID (ID injected by api-gateway from JWT)
+    public Optional<UserProfileResponse> getProfile(UUID userId) {
+        return userRepository.findById(userId)
+            .map(u -> new UserProfileResponse(u.getId(), u.getEmail(), u.getUsername(),
+                                              u.isEmailVerified(), u.getCreatedAt()));
+    }
+
     public AuthResponse register(RegisterRequest request) {
         if (userRepository.existsByEmail(request.email())) {
             throw new EmailAlreadyExistsException(request.email());

--- a/services/f1-data-service/src/main/resources/application.yml
+++ b/services/f1-data-service/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 server:
   port: 8085
+  servlet:
+    context-path: /f1
 
 spring:
   application:

--- a/services/prediction-service/src/main/java/com/f1predict/prediction/controller/PredictionController.java
+++ b/services/prediction-service/src/main/java/com/f1predict/prediction/controller/PredictionController.java
@@ -9,6 +9,7 @@ import com.f1predict.prediction.service.PredictionService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -48,6 +49,26 @@ public class PredictionController {
             @PathVariable @Pattern(regexp = "^[A-Z0-9_-]{3,20}$") String raceId,
             @RequestParam(defaultValue = "RACE") @Pattern(regexp = "RACE|SPRINT") String sessionType) {
         return predictionService.getLockedPredictions(raceId, sessionType);
+    }
+
+    // #160 — Retrieve current user's prediction for a race (pre-populates UI before deadline)
+    @GetMapping("/{raceId}")
+    public ResponseEntity<PredictionResponse> get(
+            @PathVariable @Pattern(regexp = "^[A-Z0-9_-]{3,20}$") String raceId,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestParam(defaultValue = "RACE") @Pattern(regexp = "RACE|SPRINT") String sessionType) {
+        return predictionService.getPrediction(userId, raceId, sessionType)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // #160 — Retrieve existing bonus bets for a race
+    @GetMapping("/{raceId}/bets")
+    public List<BonusBetResponse> getBets(
+            @PathVariable @Pattern(regexp = "^[A-Z0-9_-]{3,20}$") String raceId,
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestParam(defaultValue = "RACE") @Pattern(regexp = "RACE|SPRINT") String sessionType) {
+        return predictionService.getBets(userId, raceId, sessionType);
     }
 
     @PostMapping("/{raceId}/bets")

--- a/services/prediction-service/src/main/java/com/f1predict/prediction/service/PredictionService.java
+++ b/services/prediction-service/src/main/java/com/f1predict/prediction/service/PredictionService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
@@ -115,6 +116,21 @@ public class PredictionService {
         bet.setBetValue(req.betValue());
         BonusBet saved = bonusBetRepository.save(bet);
         return new BonusBetResponse(saved.getId(), saved.getBetType(), saved.getStake(), saved.getBetValue());
+    }
+
+    // #160 — Retrieve a user's existing prediction (returns empty if none yet)
+    public Optional<PredictionResponse> getPrediction(UUID userId, String raceId, String sessionType) {
+        return predictionRepository.findByUserIdAndRaceIdAndSessionType(userId, raceId, sessionType)
+            .map(this::toResponse);
+    }
+
+    // #160 — Retrieve a user's bonus bets for a race
+    public List<BonusBetResponse> getBets(UUID userId, String raceId, String sessionType) {
+        return predictionRepository.findByUserIdAndRaceIdAndSessionType(userId, raceId, sessionType)
+            .map(p -> bonusBetRepository.findByPredictionId(p.getId()).stream()
+                .map(b -> new BonusBetResponse(b.getId(), b.getBetType(), b.getStake(), b.getBetValue()))
+                .toList())
+            .orElse(List.of());
     }
 
     public List<InternalPredictionResponse> getLockedPredictions(String raceId, String sessionType) {


### PR DESCRIPTION
## Summary

- **Test environment at `test.pitwall.guru`** — auto-deploys from `main` alongside production, fully isolated Docker project on same VPS (port 8090)
- **Fix f1-data-service routing** — endpoints were unreachable via gateway due to missing context-path (#159)
- **GET /predictions/{raceId}** and **GET /predictions/{raceId}/bets** — retrieve existing predictions for pre-populating the UI (#160)
- **GET /auth/me** — current user profile endpoint, gateway-protected so `X-User-Id` is injected (#161)

## Changes

| File | Change |
|---|---|
| `.github/workflows/deploy.yml` | New `deploy-test` job: same images, isolated compose project `f1predict-test`, port 8090 |
| `.github/deploy/docker-compose.test.yml.tpl` | Test compose overlay (infra on different host ports, `APNS_PRODUCTION: false`) |
| `.github/deploy/nginx-test.conf` | nginx server block for test.pitwall.guru → localhost:8090 (one-time manual setup) |
| `services/f1-data-service/src/main/resources/application.yml` | Add `server.servlet.context-path: /f1` (#159) |
| `services/prediction-service/...PredictionController.java` | Add GET endpoints for prediction + bets (#160) |
| `services/prediction-service/...PredictionService.java` | Add `getPrediction()` and `getBets()` methods (#160) |
| `services/auth-service/...AuthController.java` | Add `GET /auth/me` (#161) |
| `services/auth-service/...AuthService.java` | Add `getProfile(UUID)` method (#161) |
| `services/auth-service/...UserProfileResponse.java` | New DTO for profile response (#161) |
| `api-gateway/...JwtGatewayFilter.java` | Add `/auth/me` to PROTECTED_PREFIXES so it requires JWT (#161) |
| `.gitignore` | Exclude `.claude/settings.local.json` (contained OAuth token) |

## One-time VPS setup needed for test.pitwall.guru

```bash
# On the VPS as root — only once
sudo cp /path/to/repo/.github/deploy/nginx-test.conf /etc/nginx/sites-enabled/nginx-test.conf
sudo nginx -t && sudo systemctl reload nginx
```

## GitHub setup needed

1. Create **`test` environment** in repo Settings → Environments
2. Add repo variable **`TEST_BASE_URL`** = `http://<VPS_IP>:8090` (change to `https://test.pitwall.guru` after nginx)
3. Add **Cloudflare DNS**: `test CNAME → pitwall.guru` (or A record to same VPS IP)

## Test plan

- [ ] CI builds all 8 images green
- [ ] `deploy` job (production) passes all 5 smoke tests
- [ ] `deploy-test` job starts f1predict-test stack on port 8090
- [ ] Test smoke tests: gateway ready → register → leagues create → analytics 200
- [ ] `GET /auth/me` returns `{id, email, username, emailVerified}` with valid token
- [ ] `GET /predictions/{raceId}` returns 404 (no prediction yet) — no longer 405
- [ ] `GET /f1/races/{id}/deadline` returns 404 (correct — no data yet, but no longer 404 from wrong route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)