### PR TITLE
feat: fix port conflicts, f1-data endpoints, CORS, Cloudflare Pages deploy

### DIFF
--- a/.github/deploy/docker-compose.prod.yml.tpl
+++ b/.github/deploy/docker-compose.prod.yml.tpl
@@ -25,6 +25,8 @@ services:
   api-gateway:
     image: IMAGE_PREFIX/api-gateway:IMAGE_TAG
     restart: unless-stopped
+    ports:
+      - "8080:8080"
     environment:
       JWT_SECRET: "${JWT_SECRET}"
     # In production, only wait for Redis (fast); backend services use service_started

--- a/.github/deploy/docker-compose.test.yml.tpl
+++ b/.github/deploy/docker-compose.test.yml.tpl
@@ -1,12 +1,14 @@
 # Test compose override — image tags substituted by deploy.yml, project-name f1predict-test
 # Merge: docker compose --project-name f1predict-test -f docker-compose.yml -f docker-compose.test.yml up
+#
+# Base docker-compose.yml has NO host port bindings — all services talk via Docker network.
+# This overlay only needs to expose api-gateway on 8090 so nginx can reach it from the host.
+# Infra (postgres, redis, rabbitmq) is internal to the f1predict-test Docker network.
 
 services:
-  # Expose infra on distinct host ports so prod and test coexist on the same VPS
+  # Give infra more time to start on VPS cold boot
   postgres:
     restart: unless-stopped
-    ports:
-      - "5433:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U f1predict"]
       interval: 10s
@@ -16,19 +18,9 @@ services:
 
   redis:
     restart: unless-stopped
-    ports:
-      - "6380:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
   rabbitmq:
     restart: unless-stopped
-    ports:
-      - "5673:5672"
-      - "15673:15672"
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 30s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,17 @@ jobs:
 
       - name: Wait for all services to pass health checks
         run: |
+          # wait_healthy <name> <port> [<context-path>]
+          # context-path defaults to empty (most services); f1-data-service uses /f1
           wait_healthy() {
             local name=$1
             local port=$2
-            echo "Waiting for $name (/actuator/health on $port)..."
+            local ctx=${3:-}
+            echo "Waiting for $name (${ctx}/actuator/health on $port)..."
             for i in $(seq 1 60); do
               local status
               status=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 \
-                "http://localhost:${port}/actuator/health" 2>/dev/null || echo "000")
+                "http://localhost:${port}${ctx}/actuator/health" 2>/dev/null || echo "000")
               if [ "$status" = "200" ]; then
                 echo "  $name is healthy"
                 return 0
@@ -75,18 +78,18 @@ jobs:
               sleep 5
             done
             echo "  $name did not become healthy after 5 minutes"
-            docker compose logs "$name" --tail=30
+            docker compose -f docker-compose.yml -f docker-compose.dev.yml logs "$name" --tail=30
             return 1
           }
 
-          wait_healthy auth-service         8081 || exit 1
-          wait_healthy prediction-service   8082 || exit 1
-          wait_healthy league-service       8083 || exit 1
-          wait_healthy scoring-service      8084 || exit 1
-          wait_healthy f1-data-service      8085 || exit 1
-          wait_healthy notification-service 8086 || exit 1
-          wait_healthy analytics-service   8087 || exit 1
-          wait_healthy api-gateway         8080 || exit 1
+          wait_healthy auth-service         8081     || exit 1
+          wait_healthy prediction-service   8082     || exit 1
+          wait_healthy league-service       8083     || exit 1
+          wait_healthy scoring-service      8084     || exit 1
+          wait_healthy f1-data-service      8085 /f1 || exit 1
+          wait_healthy notification-service 8086     || exit 1
+          wait_healthy analytics-service   8087      || exit 1
+          wait_healthy api-gateway         8080      || exit 1
 
       - name: Smoke test - all routes reachable via api-gateway
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           pull_with_retry rabbitmq:3-management-alpine || exit 1
 
       - name: Build and start all services
-        run: docker compose up -d --build
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
         timeout-minutes: 15
 
       - name: Wait for all services to pass health checks
@@ -115,11 +115,11 @@ jobs:
 
       - name: Print all service logs on failure
         if: failure()
-        run: docker compose logs --tail=50
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml logs --tail=50
 
       - name: Tear down
         if: always()
-        run: docker compose down -v
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v
 
   mobile-typecheck:
     name: Mobile TypeScript Check

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,46 @@
+name: Deploy Web App
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/deploy-web.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Build (production)
+        working-directory: web
+        env:
+          VITE_API_BASE_URL: https://pitwall.guru
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy web/dist --project-name=pitwall-app --branch=main

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -6,6 +6,24 @@ spring:
     name: api-gateway
   cloud:
     gateway:
+      globalcors:
+        corsConfigurations:
+          '[/**]':
+            allowedOrigins:
+              - "https://app.pitwall.guru"
+              - "https://app.test.pitwall.guru"
+              - "http://localhost:3000"
+              - "http://localhost:5173"
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - PATCH
+              - DELETE
+              - OPTIONS
+            allowedHeaders: "*"
+            allowCredentials: true
+            maxAge: 3600
       routes:
         - id: auth-service
           uri: http://auth-service:8081

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,56 @@
+# Local development overrides — adds host port bindings so you can connect directly
+# Usage: docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# Services reach each other via Docker network (no host ports needed for that).
+# These ports are only for direct access from your dev machine: psql, redis-cli,
+# RabbitMQ management UI, curl to individual services, etc.
+
+services:
+  postgres:
+    ports:
+      - "5432:5432"
+
+  redis:
+    ports:
+      - "6379:6379"
+
+  rabbitmq:
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
+  auth-service:
+    ports:
+      - "8081:8081"
+
+  prediction-service:
+    ports:
+      - "8082:8082"
+
+  league-service:
+    ports:
+      - "8083:8083"
+
+  scoring-service:
+    ports:
+      - "8084:8084"
+
+  f1-data-service:
+    ports:
+      - "8085:8085"
+
+  notification-service:
+    ports:
+      - "8086:8086"
+
+  analytics-service:
+    ports:
+      - "8087:8087"
+
+  api-gateway:
+    ports:
+      - "8080:8080"
+
+  web:
+    ports:
+      - "3000:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,17 +193,17 @@ services:
       redis:
         condition: service_healthy
       auth-service:
-        condition: service_healthy
+        condition: service_started
       prediction-service:
-        condition: service_healthy
+        condition: service_started
       league-service:
-        condition: service_healthy
+        condition: service_started
       scoring-service:
-        condition: service_healthy
+        condition: service_started
       f1-data-service:
-        condition: service_healthy
+        condition: service_started
       notification-service:
-        condition: service_healthy
+        condition: service_started
 
   web:
     build: ./web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       POSTGRES_USER: f1predict
       POSTGRES_PASSWORD: f1predict
       POSTGRES_DB: postgres
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./infra/init-db.sql:/docker-entrypoint-initdb.d/init.sql
@@ -18,8 +16,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -28,9 +24,6 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management-alpine
-    ports:
-      - "5672:5672"
-      - "15672:15672"
     environment:
       RABBITMQ_DEFAULT_USER: f1predict
       RABBITMQ_DEFAULT_PASS: f1predict
@@ -44,8 +37,6 @@ services:
     build:
       context: .
       dockerfile: services/auth-service/Dockerfile
-    ports:
-      - "8081:8081"
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/auth_db
       SPRING_DATASOURCE_USERNAME: f1predict
@@ -64,8 +55,6 @@ services:
     build:
       context: .
       dockerfile: services/prediction-service/Dockerfile
-    ports:
-      - "8082:8082"
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/prediction_db
       SPRING_DATASOURCE_USERNAME: f1predict
@@ -85,8 +74,6 @@ services:
     build:
       context: .
       dockerfile: services/league-service/Dockerfile
-    ports:
-      - "8083:8083"
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/league_db
       SPRING_DATASOURCE_USERNAME: f1predict
@@ -106,8 +93,6 @@ services:
     build:
       context: .
       dockerfile: services/scoring-service/Dockerfile
-    ports:
-      - "8084:8084"
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/scoring_db
       SPRING_DATASOURCE_USERNAME: f1predict
@@ -128,8 +113,6 @@ services:
     build:
       context: .
       dockerfile: services/notification-service/Dockerfile
-    ports:
-      - "8086:8086"
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/notification_db
       SPRING_DATASOURCE_USERNAME: f1predict
@@ -159,8 +142,6 @@ services:
     build:
       context: .
       dockerfile: services/f1-data-service/Dockerfile
-    ports:
-      - "8085:8085"
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/f1data_db
       SPRING_DATASOURCE_USERNAME: f1predict
@@ -182,8 +163,6 @@ services:
     build:
       context: .
       dockerfile: services/analytics-service/Dockerfile
-    ports:
-      - "8087:8087"
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/analytics_db
       SPRING_DATASOURCE_USERNAME: f1predict
@@ -207,8 +186,6 @@ services:
     build:
       context: .
       dockerfile: api-gateway/Dockerfile
-    ports:
-      - "8080:8080"
     environment:
       JWT_SECRET: change-me-in-production-use-256-bit-key-minimum
       SPRING_DATA_REDIS_HOST: redis
@@ -230,8 +207,6 @@ services:
 
   web:
     build: ./web
-    ports:
-      - "3000:80"
     environment:
       # VITE vars are baked in at build time by Vite — api-gateway is a Docker-internal
       # hostname the browser cannot resolve, so use the host-mapped port instead.

--- a/services/f1-data-service/src/main/java/com/f1predict/f1data/controller/CalendarController.java
+++ b/services/f1-data-service/src/main/java/com/f1predict/f1data/controller/CalendarController.java
@@ -1,0 +1,93 @@
+package com.f1predict.f1data.controller;
+
+import com.f1predict.f1data.model.Race;
+import com.f1predict.f1data.repository.RaceRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.List;
+
+@RestController
+@RequestMapping("/calendar")
+public class CalendarController {
+
+    private final RaceRepository raceRepository;
+
+    public CalendarController(RaceRepository raceRepository) {
+        this.raceRepository = raceRepository;
+    }
+
+    record RaceResponse(
+        String id,
+        String name,
+        String circuitName,
+        String country,
+        String city,
+        String raceDateTime,
+        String qualifyingDateTime,
+        int round,
+        int season,
+        String status,
+        boolean sprintWeekend
+    ) {}
+
+    record CalendarResponse(int season, List<RaceResponse> races) {}
+
+    private static String computeStatus(Race race) {
+        if (race.getRaceDate() == null) return "upcoming";
+        Instant now = Instant.now();
+        if (race.getQualifyingDeadline() != null && race.getQualifyingDeadline().isAfter(now)) {
+            return "upcoming";
+        }
+        if (race.getRaceDate().isAfter(now)) {
+            return "upcoming";
+        }
+        if (race.getRaceDate().plusSeconds(4 * 3600).isBefore(now)) {
+            return "finished";
+        }
+        return "live";
+    }
+
+    private static RaceResponse toResponse(Race race) {
+        return new RaceResponse(
+            race.getId(),
+            race.getRaceName(),
+            race.getCircuitName(),
+            race.getCountry(),
+            race.getCity(),
+            race.getRaceDate() != null ? race.getRaceDate().toString() : null,
+            race.getQualifyingDeadline() != null ? race.getQualifyingDeadline().toString() : null,
+            race.getRound(),
+            race.getSeason(),
+            computeStatus(race),
+            race.isSprintWeekend()
+        );
+    }
+
+    /** GET /f1/calendar/current */
+    @GetMapping("/current")
+    public CalendarResponse getCurrentCalendar() {
+        int season = LocalDate.now(ZoneOffset.UTC).getYear();
+        List<RaceResponse> races = raceRepository.findBySeason(season).stream()
+            .sorted(Comparator.comparingInt(Race::getRound))
+            .map(CalendarController::toResponse)
+            .toList();
+        return new CalendarResponse(season, races);
+    }
+
+    /** GET /f1/calendar/{season} — fetch a specific season */
+    @GetMapping("/{season}")
+    public CalendarResponse getCalendarBySeason(@PathVariable int season) {
+        List<RaceResponse> races = raceRepository.findBySeason(season).stream()
+            .sorted(Comparator.comparingInt(Race::getRound))
+            .map(CalendarController::toResponse)
+            .toList();
+        return new CalendarResponse(season, races);
+    }
+}

--- a/services/f1-data-service/src/main/java/com/f1predict/f1data/controller/DriverController.java
+++ b/services/f1-data-service/src/main/java/com/f1predict/f1data/controller/DriverController.java
@@ -1,0 +1,52 @@
+package com.f1predict.f1data.controller;
+
+import com.f1predict.f1data.repository.DriverRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.List;
+
+@RestController
+@RequestMapping("/drivers")
+public class DriverController {
+
+    private final DriverRepository driverRepository;
+
+    public DriverController(DriverRepository driverRepository) {
+        this.driverRepository = driverRepository;
+    }
+
+    record DriverResponse(
+        String id,
+        String name,
+        String code,
+        String team,
+        Integer number,
+        String nationality,
+        int season
+    ) {}
+
+    /** GET /f1/drivers?season=2026 (defaults to current year) */
+    @GetMapping
+    public List<DriverResponse> getDrivers(
+            @RequestParam(required = false) Integer season) {
+        int s = season != null ? season : LocalDate.now(ZoneOffset.UTC).getYear();
+        return driverRepository.findBySeason(s).stream()
+            .sorted(Comparator.comparingInt(d -> d.getDriverNumber() != null ? d.getDriverNumber() : 99))
+            .map(d -> new DriverResponse(
+                d.getCode(),
+                d.getFirstName() + " " + d.getLastName(),
+                d.getCode(),
+                d.getConstructorName(),
+                d.getDriverNumber(),
+                d.getNationality(),
+                d.getSeason()
+            ))
+            .toList();
+    }
+}

--- a/services/f1-data-service/src/main/java/com/f1predict/f1data/controller/RaceController.java
+++ b/services/f1-data-service/src/main/java/com/f1predict/f1data/controller/RaceController.java
@@ -1,30 +1,144 @@
 package com.f1predict.f1data.controller;
 
+import com.f1predict.f1data.model.Race;
+import com.f1predict.f1data.model.RaceResult;
+import com.f1predict.f1data.model.Session;
 import com.f1predict.f1data.repository.RaceRepository;
+import com.f1predict.f1data.repository.RaceResultRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.List;
 
 @RestController
 @RequestMapping("/races")
 public class RaceController {
 
     private final RaceRepository raceRepository;
+    private final RaceResultRepository raceResultRepository;
 
-    public RaceController(RaceRepository raceRepository) {
+    public RaceController(RaceRepository raceRepository, RaceResultRepository raceResultRepository) {
         this.raceRepository = raceRepository;
+        this.raceResultRepository = raceResultRepository;
     }
+
+    // --- DTOs ---
 
     record DeadlineResponse(String raceId, Instant qualifyingDeadline) {}
 
+    record RaceResponse(
+        String id,
+        String name,
+        String circuitName,
+        String country,
+        String city,
+        String raceDateTime,
+        String qualifyingDateTime,
+        int round,
+        int season,
+        String status,
+        boolean sprintWeekend
+    ) {}
+
+    record RaceResultResponse(
+        String raceId,
+        int position,
+        String driverId,
+        String driverCode,
+        String timeOrStatus,
+        boolean fastestLap
+    ) {}
+
+    record CalendarResponse(int season, List<RaceResponse> races) {}
+
+    // --- Helpers ---
+
+    private static String computeStatus(Race race) {
+        if (race.getRaceDate() == null) return "upcoming";
+        Instant now = Instant.now();
+        // Live window: qualifying deadline passed but race is within ~4 hours ago
+        if (race.getQualifyingDeadline() != null && race.getQualifyingDeadline().isAfter(now)) {
+            return "upcoming";
+        }
+        // Race day: within 4 hours either side of race start
+        if (race.getRaceDate().isAfter(now)) {
+            return "upcoming";
+        }
+        // Race started more than 4 hours ago → finished
+        if (race.getRaceDate().plusSeconds(4 * 3600).isBefore(now)) {
+            return "finished";
+        }
+        return "live";
+    }
+
+    private static RaceResponse toResponse(Race race) {
+        return new RaceResponse(
+            race.getId(),
+            race.getRaceName(),
+            race.getCircuitName(),
+            race.getCountry(),
+            race.getCity(),
+            race.getRaceDate() != null ? race.getRaceDate().toString() : null,
+            race.getQualifyingDeadline() != null ? race.getQualifyingDeadline().toString() : null,
+            race.getRound(),
+            race.getSeason(),
+            computeStatus(race),
+            race.isSprintWeekend()
+        );
+    }
+
+    // --- Endpoints ---
+
+    /** GET /f1/races/{raceId}/deadline */
     @GetMapping("/{raceId}/deadline")
     public ResponseEntity<DeadlineResponse> getDeadline(@PathVariable String raceId) {
         return raceRepository.findById(raceId)
             .map(race -> ResponseEntity.ok(new DeadlineResponse(raceId, race.getQualifyingDeadline())))
             .orElse(ResponseEntity.notFound().build());
     }
+
+    /** GET /f1/races/next — upcoming race closest to now */
+    @GetMapping("/next")
+    public ResponseEntity<RaceResponse> getNextRace() {
+        int season = LocalDate.now(ZoneOffset.UTC).getYear();
+        Instant now = Instant.now();
+        return raceRepository.findBySeason(season).stream()
+            .filter(r -> r.getRaceDate() == null || r.getRaceDate().isAfter(now))
+            .min(Comparator.comparing(r -> r.getRaceDate() != null ? r.getRaceDate() : Instant.MAX))
+            .map(race -> ResponseEntity.ok(toResponse(race)))
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    /** GET /f1/races/{raceId}/results?sessionType=RACE */
+    @GetMapping("/{raceId}/results")
+    public List<RaceResultResponse> getResults(
+            @PathVariable String raceId,
+            @RequestParam(defaultValue = "RACE") String sessionType) {
+        Session.SessionType type;
+        try {
+            type = Session.SessionType.valueOf(sessionType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            type = Session.SessionType.RACE;
+        }
+        return raceResultRepository.findByRaceIdAndSessionType(raceId, type).stream()
+            .sorted(Comparator.comparingInt(r -> r.getFinishPosition() != null ? r.getFinishPosition() : 99))
+            .map(r -> new RaceResultResponse(
+                raceId,
+                r.getFinishPosition() != null ? r.getFinishPosition() : 0,
+                r.getDriverCode(),
+                r.getDriverCode(),
+                r.getStatus().name(),
+                r.isFastestLap()
+            ))
+            .toList();
+    }
+
 }

--- a/services/f1-data-service/src/main/java/com/f1predict/f1data/model/Driver.java
+++ b/services/f1-data-service/src/main/java/com/f1predict/f1data/model/Driver.java
@@ -21,6 +21,9 @@ public class Driver {
     @Column(length = 50)
     private String nationality;
 
+    @Column(length = 100)
+    private String constructorName;
+
     @Column(nullable = false)
     private int season;
 
@@ -62,6 +65,14 @@ public class Driver {
 
     public void setNationality(String nationality) {
         this.nationality = nationality;
+    }
+
+    public String getConstructorName() {
+        return constructorName;
+    }
+
+    public void setConstructorName(String constructorName) {
+        this.constructorName = constructorName;
     }
 
     public int getSeason() {

--- a/services/f1-data-service/src/main/java/com/f1predict/f1data/model/Race.java
+++ b/services/f1-data-service/src/main/java/com/f1predict/f1data/model/Race.java
@@ -25,6 +25,9 @@ public class Race {
     @Column(nullable = false, length = 100)
     private String country;
 
+    @Column(length = 100)
+    private String city;
+
     private Instant raceDate;
 
     private Instant qualifyingDeadline;
@@ -78,6 +81,14 @@ public class Race {
 
     public void setCountry(String country) {
         this.country = country;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
     }
 
     public Instant getRaceDate() {

--- a/services/f1-data-service/src/main/resources/db/migration/V3__add_city_and_constructor.sql
+++ b/services/f1-data-service/src/main/resources/db/migration/V3__add_city_and_constructor.sql
@@ -1,0 +1,4 @@
+-- #162 Add city to races and constructor_name to drivers
+-- city is nullable so existing rows are unaffected until populated via admin API / seed data
+ALTER TABLE races ADD COLUMN IF NOT EXISTS city VARCHAR(100);
+ALTER TABLE drivers ADD COLUMN IF NOT EXISTS constructor_name VARCHAR(100);

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -1,14 +1,33 @@
 import apiClient, { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from './client'
-import type { AuthResponse, RefreshTokenResponse } from './types'
+import type { AuthResponse, RefreshTokenResponse, User } from './types'
+
+/** Shape returned by GET /auth/me */
+interface ProfileResponse {
+  id: string
+  email: string
+  username: string
+  emailVerified: boolean
+  createdAt: string
+}
+
+async function fetchProfile(): Promise<User> {
+  const { data } = await apiClient.get<ProfileResponse>('/auth/me')
+  return {
+    id: data.id,
+    email: data.email,
+    displayName: data.username,
+  }
+}
 
 export async function login(email: string, password: string): Promise<AuthResponse> {
-  const { data } = await apiClient.post<AuthResponse>('/auth/login', {
-    email,
-    password,
-  })
+  const { data } = await apiClient.post<{ accessToken: string; refreshToken: string; expiresIn: number }>(
+    '/auth/login',
+    { email, password },
+  )
   localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken)
   localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken)
-  return data
+  const user = await fetchProfile()
+  return { ...data, user }
 }
 
 export async function register(
@@ -16,14 +35,14 @@ export async function register(
   password: string,
   displayName: string,
 ): Promise<AuthResponse> {
-  const { data } = await apiClient.post<AuthResponse>('/auth/register', {
-    email,
-    password,
-    displayName,
-  })
+  const { data } = await apiClient.post<{ accessToken: string; refreshToken: string; expiresIn: number }>(
+    '/auth/register',
+    { email, password, username: displayName },
+  )
   localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken)
   localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken)
-  return data
+  const user = await fetchProfile()
+  return { ...data, user }
 }
 
 export async function logout(): Promise<void> {
@@ -44,3 +63,5 @@ export async function refreshToken(): Promise<RefreshTokenResponse> {
   localStorage.setItem(REFRESH_TOKEN_KEY, data.refreshToken)
   return data
 }
+
+export { fetchProfile }

--- a/web/src/api/f1data.ts
+++ b/web/src/api/f1data.ts
@@ -2,17 +2,17 @@ import apiClient from './client'
 import type { Calendar, Driver, RaceResult } from './types'
 
 export async function getCalendar(): Promise<Calendar> {
-  const { data } = await apiClient.get<Calendar>('/f1data/calendar')
+  const { data } = await apiClient.get<Calendar>('/f1/calendar/current')
   return data
 }
 
 export async function getDrivers(): Promise<Driver[]> {
-  const { data } = await apiClient.get<Driver[]>('/f1data/drivers')
+  const { data } = await apiClient.get<Driver[]>('/f1/drivers')
   return data
 }
 
 export async function getRaceResults(raceId: string): Promise<RaceResult[]> {
-  const { data } = await apiClient.get<RaceResult[]>(`/f1data/races/${raceId}/results`)
+  const { data } = await apiClient.get<RaceResult[]>(`/f1/races/${raceId}/results`)
   return data
 }
 
@@ -25,6 +25,11 @@ export interface RaceState {
 }
 
 export async function getLiveRaceState(): Promise<RaceState> {
-  const { data } = await apiClient.get<RaceState>('/live/race-state')
+  const { data } = await apiClient.get<RaceState>('/f1/live/race-state')
+  return data
+}
+
+export async function getNextRace() {
+  const { data } = await apiClient.get('/f1/races/next')
   return data
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -13,6 +13,8 @@ export interface User {
 export interface AuthResponse {
   accessToken: string
   refreshToken: string
+  expiresIn: number
+  /** Populated client-side by fetching /auth/me after token issuance */
   user: User
 }
 


### PR DESCRIPTION
## Summary

- **Port conflict fix**: Removes ALL host port bindings from base `docker-compose.yml` — both infra (postgres/redis/rabbitmq) and all microservices. This was causing test deploy to fail because Docker Compose merges port arrays, so test redis was trying to bind both `:6379` and `:6380` while prod already owned `:6379`. New `docker-compose.dev.yml` restores host ports for local development.
- **CORS**: Adds `globalcors` to api-gateway allowing `app.pitwall.guru`, `app.test.pitwall.guru`, `localhost:3000/5173`
- **f1-data API** (closes #162): Flyway V3 migration adds `city` to races + `constructor_name` to drivers; new `CalendarController` (`GET /f1/calendar/current`), `DriverController` (`GET /f1/drivers`), and race results/next race endpoints
- **Web app API paths**: Fixes wrong paths in `f1data.ts` (`/f1data/*` → `/f1/*`) and fixes auth flow to fetch `/auth/me` after login/register
- **Cloudflare Pages**: New `deploy-web.yml` workflow builds React with `VITE_API_BASE_URL=https://pitwall.guru` and deploys via Wrangler to `pitwall-app` CF Pages project

## Test plan
- [ ] Prod deploy: `docker compose -f docker-compose.yml -f docker-compose.prod.yml up` — no port conflicts
- [ ] Test deploy: `docker compose --project-name f1predict-test -f docker-compose.yml -f docker-compose.test.yml up` — no port conflicts (redis/postgres/rabbitmq are internal only)
- [ ] `GET /f1/calendar/current` returns season + races list
- [ ] `GET /f1/drivers` returns drivers for current season
- [ ] `GET /f1/races/{id}/results` returns race results
- [ ] Login/register → user profile populated via `/auth/me`
- [ ] CF Pages deploy workflow triggers on push to main (requires `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)